### PR TITLE
Fix typos and arrest summaries in early lessons

### DIFF
--- a/01_Intro_to_R_protests.qmd
+++ b/01_Intro_to_R_protests.qmd
@@ -44,7 +44,7 @@ editor_options:
 
 # Introduction
 
-This is the first set of notes for an introduction to R programming from criminology and criminal justice. These notes assume that you have the latest version of R and R Studio installed. We are also assuming that you know how to start a new script file and submit code to the R console. From that basic knowledge about using R, we are going to start with `2+2` and by the end of this set of notes you will load in a dataset on protests in the United States (mostly), create a few plots, count some incidents, and be able to do some basic data manipulations. Our aim is to build a firm foundation on which we will build throughout this set of notes.
+This is the first set of notes for an introduction to R programming from criminology and criminal justice. These notes assume that you have the latest version of R and RStudio installed. We are also assuming that you know how to start a new script file and submit code to the R console. From that basic knowledge about using R, we are going to start with `2+2` and by the end of this set of notes you will load in a dataset on protests in the United States (mostly), create a few plots, count some incidents, and be able to do some basic data manipulations. Our aim is to build a firm foundation on which we will build throughout this set of notes.
 
 R sometimes provides useful help as to how to do something, such as choosing the right function or figuring what the syntax of a line of code should be. Let's say we're stumped as to what the `sqrt()` function does. Just type `?sqrt` at the R prompt to read documentation on `sqrt()`. Most help pages have examples at the bottom that can give you a better idea about how the function works. R has over 7,000 functions and an often seemingly inconsistent syntax. As you do more complex work with R (such as using new packages), the Help tab can be useful. 
 
@@ -155,7 +155,7 @@ setwd("C:/Users/greg_/CRIM6002/notes/R4crim")
 ```
 Note that for all platforms, Windows, Macs, and Linux, the working directory only uses forward slashes. So Windows users be careful... most Windows applications use backslashes, but in an effort to make R scripts work across all platforms, R requires forward slashes. Backslashes have a different use in R that you will meet later.
 
-If you do not know how to write your working directory, here comes R Studio to the rescue. In R Studio click Session -> Set Working Directory -> Choose Directory. Then click through to navigate to the working directory that you want to use. When you find it click "Select Folder". Then look over at the console. R Studio will construct the right `setwd()` syntax for you. Copy and paste that into your script for use later. No need to have to click through the Session menu again now that you have your `setwd()` set up.
+If you do not know how to write your working directory, here comes RStudio to the rescue. In RStudio click Session -> Set Working Directory -> Choose Directory. Then click through to navigate to the working directory that you want to use. When you find it click "Select Folder". Then look over at the console. RStudio will construct the right `setwd()` syntax for you. Copy and paste that into your script for use later. No need to have to click through the Session menu again now that you have your `setwd()` set up.
 
 Now you can use R functions to load in any datasets that are in your working folder. If you have done your `setwd()` correctly, you shouldn't get any errors because R will know exactly where to look for the data files. If the working directory that you've given in the `setwd()` isn't right, R will think the file doesn't even exist. For example, if you give the path for, say, your R4econ folder, R won't be able to load data because the file isn't stored in what R thinks is your working directory. With that out of the way, let's load a dataset.
 
@@ -317,7 +317,7 @@ Hmmm... it looks like there are some missing values in the `Attendees` column. R
 dataProtest |>
    summarize(mean(Attendees, na.rm=TRUE))
 ```
-Perhaps we are interested any several data summaries at the same time. No problem. Just include them all in `summarize()`.
+Perhaps we are interested in several data summaries at the same time. No problem. Just include them all in `summarize()`.
 ```{r}
 dataProtest |>
    summarize(average = mean(Attendees, na.rm=TRUE),
@@ -346,7 +346,7 @@ The first argument is the string from which to extract the substring. The second
 ```{r}
 str_sub("Philadelphia, PA", -2)
 ```
-There are other R functions that can extract substrings including `substring()`, `substr()`, and `gsub()`. I am introducing you to `str_sub()` since because it is the only one that lets you put negative numbers in the second and third arguments to easily grab substrings from the end. This is a very useful feature.
+There are other R functions that can extract substrings including `substring()`, `substr()`, and `gsub()`. I am introducing you to `str_sub()` because it is the only one that lets you put negative numbers in the second and third arguments to easily grab substrings from the end. This is a very useful feature.
 
 With `str_sub()` now in our toolbox, we can make a new column called `state` that contains the state in which the protest occurred. 
 ```{r}
@@ -354,7 +354,7 @@ dataProtest <- dataProtest |>
    mutate(state=str_sub(Location, -2))
 head(dataProtest)
 ```
-Peeking at the first few rows of `dataProtest` we can see that there is a new column with the state abbreviation. Please, always check that your code does what you intended to do. Run, check, run, check, one line at a time.
+Peeking at the first few rows of `dataProtest` we can see that there is a new column with the state abbreviation. Please always check that your code does what you intended to do. Run, check, run, check, one line at a time.
 
 So you can see that `mutate()` is useful for making new data features computed based on other features. We also will use it to edit or clean up data. Let's check what these state abbreviations look like. 
 ```{r}
@@ -523,7 +523,7 @@ Interested in which "state" has the largest average protest size? Use `slice_max
 dataProtest |>
   group_by(state) |>
   summarize(Average=mean(Attendees, na.rm=TRUE)) |>
-  slice_max(n=1,Average)
+  slice_max(order_by = Average, n = 1)
 ```
 
 We can also simply arrange the rows in descending order of average protest size.
@@ -551,7 +551,7 @@ Note: You may encounter code with `melt()`, `cast()`, `reshape()`, `gather()`, a
 ```{r}
 library(tidyr)
 ```
-Let's say that we are interested in determining which states have fewer civil rights protesters than non-civil rights protesters. With our existing `group_by()` and `sumamrize()` skills we can tabulate the number of protesters by state and by type of protest.
+Let's say that we are interested in determining which states have fewer civil rights protesters than non-civil rights protesters. With our existing `group_by()` and `summarize()` skills we can tabulate the number of protesters by state and by type of protest.
 ```{r}
 dataProtest |>
    group_by(state, civilrights) |>
@@ -578,7 +578,7 @@ dataProtest |>
                names_prefix = "CR") |>
    filter(CR1 < CR0)
 ```
-By spreading the columns out wide made it easier to make our calculation within each state. There is usually a way to avoid `pivot_wider()` and still get the right answer. For example,
+Spreading the columns out wide made it easier to make our calculation within each state. There is usually a way to avoid `pivot_wider()` and still get the right answer. For example,
 ```{r}
 dataProtest |>
   group_by(state) |>
@@ -614,7 +614,7 @@ dataProtest |>
    group_by(state, timePeriod) |>
    summarize(totProtesters = sum(Attendees, na.rm=TRUE))
 ```
-The results is still "grouped" at this point. Be sure to `ungroup()` so that subsequent calculations do not just occur within each group. The sequence group()/summarize()/ungroup() is so common that there is a shortcut using `.by`. Either `ungroup()` or use `.by`. Then we `pivot_wider()`.
+The result is still "grouped" at this point. Be sure to `ungroup()` so that subsequent calculations do not just occur within each group. The sequence group()/summarize()/ungroup() is so common that there is a shortcut using `.by`. Either `ungroup()` or use `.by`. Then we `pivot_wider()`.
 ```{r}
 dataProtest |>
    filter(Date < "2021-01-01") |>
@@ -647,14 +647,14 @@ dataProtest |>
    mutate(ave2017_2019 = year2017_2019/3,
           pctChange = 100*(year2020-ave2017_2019)/ave2017_2019) |>
    select(state, pctChange) |>
-   slice_max(pctChange, n = 5)
+   slice_max(order_by = pctChange, n = 5)
 ```
 
 # Graphics and plots
 
 We will finish our introduction to R by exploring `Tags` a little more through some barplots and a word cloud.
 
-I will start by a special version of `mostCommon()` that will take a collection of tags and return the most common tag. This will allow us to find the most common protest type in the dataset. This function splits up the tags as we did before, and then applies `mostCommon()` to the resulting collection of tags.
+I will start with a special version of `mostCommon()` that will take a collection of tags and return the most common tag. This will allow us to find the most common protest type in the dataset. This function splits up the tags as we did before, and then applies `mostCommon()` to the resulting collection of tags.
 
 ```{r}
 mostCommonType <- function(x)
@@ -703,7 +703,7 @@ a <- dataProtest |>
 barplot(a$Attendees, names.arg = a$state)
 ```
 
-The state name labels are two big so we can shrink the "character expansion" (`cex`) by half.
+The state name labels are too big so we can shrink the "character expansion" (`cex`) by half.
 ```{r}
 barplot(a$Attendees, names.arg = a$state, cex.names=0.5)
 ```
@@ -719,7 +719,7 @@ barplot(a$Attendees, names.arg = a$state,
 We can also create a bar plot of the number of protests for the top 5 reasons.
 ```{r}
 reasons <- dataProtest$Tags |> 
-  strsplit(";") |> 
+  strsplit("; ") |> 
   unlist() |> 
   table() |>
   sort(decreasing = TRUE) |>
@@ -745,7 +745,7 @@ dataProtest$Tags |>
 
 # Review
 
-As you saw in this script, R has a lot of functions. We started of figuring how to set our file path so R knows where to look for files. We loaded the data from a .RData file and we listed all the objects in R's environment.
+As you saw in this script, R has a lot of functions. We started off figuring out how to set our file path so R knows where to look for files. We loaded the data from a .RData file and we listed all the objects in R's environment.
 
 * `setwd()` set working directory
 * `load()` load R objects saved in a .RData file
@@ -769,7 +769,7 @@ Then we worked through some basic functions to work with R objects.
 
 When working with datasets, we covered all the standard functions needed to manipulate data.
 
-* `slice()`, `slice_max()`, `slice_min()` pick out rows by there position in the dataset or by the max/min values
+* `slice()`, `slice_max()`, `slice_min()` pick out rows by their position in the dataset or by the max/min values
 * `filter()` pick out rows based on a logical expression about what is in that row
 * `select()` pick out columns by name
 * `count()` count the number of rows in a dataset or the number of rows in a dataset by groups

--- a/02_Dates_and_times.qmd
+++ b/02_Dates_and_times.qmd
@@ -17,7 +17,7 @@ format:
     html-math-method: mathjax
   pdf:
     toc: true
-    prefer-html: true
+prefer-html: true
 number-sections: true
 editor_options: 
   chunk_output_type: console
@@ -50,7 +50,7 @@ editor_options:
 
 # Introduction
 
-Working with dates and times is a lot different than working with the more familiar numbers. Months have different number of days. Sometimes we count hours of the day up to 12 and then start over. Sometimes we count hours up to 24 and then start over. Some years have 366 days. We have 24 times zones around the world. Twice a year we switch clocks for Daylight Saving Time, except in some places like Arizona. Arithmetic, such as adding one month to a date, is poorly defined. Which date is one month after January 31st? Is it February 28th? Or is it March 3rd?
+Working with dates and times is very different from working with more familiar numbers. Months have different numbers of days. Sometimes we count hours of the day up to 12 and then start over. Sometimes we count hours up to 24 and then start over. Some years have 366 days. We have 24 time zones around the world. Twice a year we switch clocks for Daylight Saving Time, except in some places like Arizona. Arithmetic, such as adding one month to a date, is poorly defined. Which date is one month after January 31st? Is it February 28th? Or is it March 3rd?
 
 Fortunately, software for working with dates exists to make these tasks easier. Unfortunately, every system seems to make their own design decisions. Excel stores dates as the number of days since January 0, 1900... that's not a typo... they count from January 0, 1900. Linux systems count days since January 1, 1970. SPSS stores times as the number of seconds since midnight October 14, 1582, the adoption date of the Gregorian calendar. Much of the world did not adopt the calendar in 1582. The American colonies did not adopt the Gregorian calendar until 1752 along with Great Britain. So beware if you are a historian digging through centuries old data. Aligning dates can become very messy.
 
@@ -62,7 +62,7 @@ Do not use `as.Date()`. `lubridate` has an easier to read date formatting, more 
 ```
 install.packages("lubridate")
 ```
-and R will hit the web, download the `lubridate` package and any supporting packages it needs (and it does need a few), and installs them. This is a one time event. Once you have `lubridate` on your machine you will not need to reinstall it every time you need it.
+and R will hit the web, download the `lubridate` package and any supporting packages it needs (and it does need a few), and installs them. This is a one-time event. Once you have `lubridate` on your machine you will not need to reinstall it every time you need it.
 
 Some of our students, particularly on Macs, have encountered trouble installing some packages for R. R will sometimes try to download the source code for the packages and compile them from scratch on your machine. Sometimes that goes well and other times it requires that you have other tools installed on your machine. An easy solution is to run
 ```
@@ -72,7 +72,7 @@ instead to insist that R finds and installs a ready-to-use version of the packag
 
 
 # Working with dates
-While `lubridate` is now installed, once per R session you will need to load `lubridate`. 
+Once `lubridate` is installed, you need to load it at the start of each R session. 
 ```{r}
 #| comment: ""
 #| message: false
@@ -81,7 +81,7 @@ library(dplyr)
 ```
 If you close R and restart it, then you'll need to run this line again.
 
-Let's reload the [sample of Chicago crime data](https://github.com/gregridgeway/R4criminology/blob/master/chicago%20crime%2020141124-20141209.RData) discussed in the introductory notes, available on the [R4Crim github site](https://github.com/gregridgeway/R4crim).
+Let's reload the [sample of Chicago crime data](https://github.com/gregridgeway/R4crim/blob/master/chicago%20crime%2020141124-20141209.RData) discussed in the introductory notes, available on the [R4Crim github site](https://github.com/gregridgeway/R4crim).
 ```{r}
 #| comment: ""
 #| results: "hold"
@@ -96,7 +96,7 @@ chicagoCrime |>
    select(Date) |>
    slice(c(1,2500,5000,7500,10000))
 ```
-As you can see the dates include the date in month/day/year format and the time on a 12 hour AM/PM clock. R has no idea that these values represent dates. You are familiar with this date formatting, but R just thinks they are strings of characters. Use `substring()` to just extract the date part, the first 10 characters of `Date`.
+As you can see, the dates include the date in month/day/year format and the time on a 12-hour AM/PM clock. R has no idea that these values represent dates. You are familiar with this date formatting, but R just thinks they are strings of characters. Use `substring()` to just extract the date part, the first 10 characters of `Date`.
 ```{r}
 #| comment: ""
 #| results: "hold"
@@ -113,10 +113,10 @@ Now let's use the `mdy()` function from the `lubridate` package to tell R that t
 #| comment: ""
 #| results: "hold"
 b <- mdy(textDate)
-is(b)
+class(b)
 b
 ```
-`b` now stores those five dates in a format that recognizes the month, day, and year. `is(b)` tells us that R is storing `b` as a date. There are different functions for other date formats depending on the ordering of the day, month and year, like `dmy()` and `ymd()` and even `mdy_hms()` for month, day, year, hours, minutes, seconds format.
+`b` now stores those five dates in a format that recognizes the month, day, and year. `class(b)` tells us that R is storing `b` as a date object. There are different functions for other date formats depending on the ordering of the day, month, and year, like `dmy()` and `ymd()` and even `mdy_hms()` for month, day, year, hours, minutes, seconds format.
 
 Now that R knows these are dates, the `lubridate` package provides a lot of functions to help you work with dates.
 ```{r}
@@ -129,7 +129,7 @@ month(b, label=TRUE, abbr=FALSE)
 wday(b, label=TRUE)
 ```
 
-Subtraction will tell you the time between two dates. How many days since December 1, 2014? How many days have passed from the values in `b` to today? The `now()` function gives you the date and time, well... right now.
+Subtraction will tell you the time between two dates. How many days since December 1, 2014? How many days have passed from the values in `b` to today? The `now()` function gives you the date and time right now.
 ```{r}
 #| comment: ""
 b - mdy("12/01/2014")
@@ -143,7 +143,7 @@ difftime(b, mdy("12/01/2014"), units = "days")
 difftime(b, mdy("12/01/2014"), units = "hours")
 ```
 
-We can add time to the dates as well
+We can add time to the dates as well.
 ```{r}
 #| comment: ""
 b + dyears(1) # adds 365 days, does not increase year by 1
@@ -180,7 +180,7 @@ mdy_hms("8/1/2014 12:00:00") |>
    force_tz("America/Chicago")
 ```
 
-Note that `force_tz()` keeps the dates and times the same, but overwrites the timezone. If you want to lookup what the date and time would be in a different timezone, then use `with_tz()`.
+Note that `force_tz()` keeps the dates and times the same, but overwrites the timezone. If you want to look up what the date and time would be in a different timezone, then use `with_tz()`.
 
 ```{r}
 #| comment: ""
@@ -198,7 +198,7 @@ Looks like by 11am on November 2, 2025, Chicago is back to Central Standard Time
 
 # Exercises
 1. At what hour does Daylight Saving Time end? (Hint: Try using `dminutes()` to add time to the date DST ends)
-2. Thanksgiving occurs on the fourth Thursday in November. On what date will Thanksgiving fall in 2020? Hints:
+2. Thanksgiving occurs on the fourth Thursday in November. On what date will Thanksgiving fall in 2025? Hints:
      + Try listing all dates in November
      + Use `wday()` to get the weekday
      + find the fourth Thursday
@@ -237,7 +237,7 @@ a |>
    summarize(min(date), max(date))
 ```
 
-2. On what date will Thanksgiving fall in 2020?
+2. On what date will Thanksgiving fall in 2025?
 ```{r}
 #| comment: ""
 data.frame(date=mdy("11/1/2025") + ddays(0:29)) |>

--- a/03_Working_with_NIBRS_data.qmd
+++ b/03_Working_with_NIBRS_data.qmd
@@ -15,7 +15,7 @@ format:
   pdf:
     toc: true
     exclude: true
-    prefer-html: true
+prefer-html: true
 number-sections: true
 editor_options: 
   chunk_output_type: console
@@ -78,7 +78,7 @@ library(lubridate)
 scan("2023_NIBRS_NATIONAL_MASTER_FILE.txt.gz",
      nlines=5, what="", sep="\n")
 ```
-As you can see the data are not pretty. This data is in "fixed-width format". Rather than separate each column of data with a delimiter (like a comma or tab), all of the data fields are placed side by side. This is a legacy format that has some benefits. First, there is no need to store delimiters. This is less important these days with cheap data storage, but storing delimiters in a dataset this size requires about 1 Gb... just to store a bunch of commas. Instead, the data come with a separate file that describes which columns of text correspond to different columns of data. The following table shows the first five rows of the NIBRS offense segment in the included `NIBRS Records Description updated.xlsx` file.
+As you can see the data are not pretty. These data are in "fixed-width format". Rather than separate each column of data with a delimiter (like a comma or tab), all of the data fields are placed side by side. This is a legacy format that has some benefits. First, there is no need to store delimiters. This is less important these days with cheap data storage, but storing delimiters in a dataset this size requires about 1 Gb... just to store a bunch of commas. Instead, the data come with a separate file that describes which columns of text correspond to different columns of data. The following table shows the first five rows of the NIBRS offense segment in the included `NIBRS Records Description updated.xlsx` file.
 
 | Positions | Field Length and Type | Field Name                              | 
 |-----------|-----------------------|-----------------------------------------|
@@ -90,7 +90,7 @@ As you can see the data are not pretty. This data is in "fixed-width format". Ra
 | 34-36     | A3                    | UCR OFFENSE CODE			               |
 | ...       | ...                   | ...                                     |
 
-The table tells us that for offense segments, the first two characters represent the segment level, characters 3 and 4 capture the state numeric code, characters 5-13 capture the ORI (a unique identifier for a law enforcement agency), and so on. The second column describes the data type, (A)lphanumeric or (N)umeric, and the width (number of characters) of the data field. Let's start by discussing the segment level. The NIBRS data is more complex than an already complex fixed-width format data file. The NIBRS data involve several data tables, separate tables for offenses, victims, offenders, property, and arrests. The data file we just loaded interleaves all of these tables. Note that the fourth row of the data we scanned in starts with "02" that signals that the rest of that row describes an offense and its format will align with the formatting table shown here. Since characters 3-4 are "50" we know from the format table that this number represents the state with code "50," which turns out to be Alaska. The next nine characters (AK0010200) is the ORI code for the law enforcement agency that reported the offense, which turns out to be the Fairbanks Police Department. If we look further to the right in that fourth row of data to characters 26-33 we get "20230101," which is the data of the criminal incident, January 1, 2023. And the three characters after the date give the offense code "23D," which is the code for theft from a building. 
+The table tells us that for offense segments, the first two characters represent the segment level, characters 3 and 4 capture the state numeric code, characters 5-13 capture the ORI (a unique identifier for a law enforcement agency), and so on. The second column describes the data type, (A)lphanumeric or (N)umeric, and the width (number of characters) of the data field. Let's start by discussing the segment level. The NIBRS data is more complex than an already complex fixed-width format data file. The NIBRS data involve several data tables, separate tables for offenses, victims, offenders, property, and arrests. The data file we just loaded interleaves all of these tables. Note that the fourth row of the data we scanned in starts with "02" that signals that the rest of that row describes an offense and its format will align with the formatting table shown here. Since characters 3-4 are "50" we know from the format table that this number represents the state with code "50," which turns out to be Alaska. The next nine characters (AK0010200) is the ORI code for the law enforcement agency that reported the offense, which turns out to be the Fairbanks Police Department. If we look further to the right in that fourth row of data to characters 26-33 we get "20230101," which is the date of the criminal incident, January 1, 2023. And the three characters after the date give the offense code "23D," which is the code for theft from a building. 
 
 This interpretation only works for lines of data with the first two characters equal to "02". The others are
 
@@ -111,7 +111,7 @@ This interpretation only works for lines of data with the first two characters e
 We will read each of these in and explore what they contain. The W1, W2, and W3 are "window segments" and represent a partial reporting. These are relatively rare records and mostly relate to arrests or recovered property related to offenses that do not appear in the 02 segment, most likely because the agency transitioned to NIBRS between the offense and the recovery/arrest.
 
 # Reading in the data
-Here's the strategy that we will use to read in the data. The data might be too big to read in all at once and still have computer memory available to clean and organize the data. Instead of reading all of it in, we are going to read in one million rows at a time. We will then examine the first two characters of each row and split rows of data by those first two characters. In this way, all the offense records will be together, and all the victim records will be together, and so one. Then we will write out all the records into segment specific files. Our computers will then have a separate file for each of the NIBRS segments.
+Here's the strategy that we will use to read in the data. The data might be too big to read in all at once and still have computer memory available to clean and organize the data. Instead of reading all of it in, we are going to read in one million rows at a time. We will then examine the first two characters of each row and split rows of data by those first two characters. In this way, all the offense records will be together, and all the victim records will be together, and so on. Then we will write out all the records into segment specific files. Our computers will then have a separate file for each of the NIBRS segments.
 
 First, I set up `infile` to connect to the large NIBRS data file, opening it in (r)ead mode. Next, I set up eight files, one for each of the segments, creating them in (w)rite mode to be gzip'd (compressed) as they are created. Then I set up a while-loop to continue to read one million lines at a time as long as there are more rows of data to read in. Within the loop I use `split()` to separate the lines of data I have read in based on the first two characters of the line. I combine the few window segments with the similar complete records (e.g. window segment on property goes with the rest of the property data). Lastly, inside the loop I write out the new batch of data, appending them to existing data from previous iterations of the while-loop. Closing all the files makes sure that all the read and write buffers get flushed to the data files and the connections are closed.
 
@@ -368,7 +368,7 @@ nibrsProp03 <- read_fwf("2023-03.txt.gz",
           STATE   = NUMERIC.STATE.CODE)
 ```
 
-Let's pull up the property record for the Fairbanks, Alaska incident 2300003 that we previously examined.
+Let's pull up the victim record for the Fairbanks, Alaska incident 2300003 that we previously examined.
 ```{r}
 nibrsProp03 |>  
    filter(ORI=="AK0010200" & INCIDENT.NUMBER=="23000003") |> 
@@ -418,7 +418,7 @@ nibrsVic04 <- read_fwf("2023-04.txt.gz",
 ```
 
 
-Let's pull up the property record for the Fairbanks, Alaska incident 2300003 that we previously examined.
+Let's pull up the victim record for the Fairbanks, Alaska incident 2300003 that we previously examined.
 ```{r}
 nibrsVic04 |>
    filter(ORI=="AK0010200" & INCIDENT.NUMBER=="23000003") |> 
@@ -492,7 +492,7 @@ nibrsOff05 |>
 If the reporting agency arrests an offender for the reported offense after submitting the initial report, the agency later submits an updated arrestee segment as an update to the initial report. The [NIBRS User's Manual](https://le.fbi.gov/file-repository/nibrs-user-manual.pdf) notes that as cases develop, police can update, delete, or add to previously submitted records. However, the submission date cuts off on March 15 of subsequent year.
 
 ```{r readArrestee} 
-# select only the rows for victim segment
+# select only the rows for the arrestee segment
 i <- grep('LEVEL "06"', fmtXL$DataField)
 j <- grep('LEVEL "07"', fmtXL$DataField)
 
@@ -605,7 +605,7 @@ nibrsBH <- read_fwf("2023-BH.txt.gz",
           STATE   = NUMERIC.STATE.CODE)
 ```
 
-Some particularly important columns are `DATE.ORI.WENT.NIBRS` containing the date when the agency first reported data to NIBRS, the `AGENCY.INDICATOR` describing what type of law enforcement agency it is (eg. city, county, state, college, tribal) or whether the agency relies on another to file its NIBRS reports (such as a transit police that reports through the municipal police). The batch header contains an estimate of the size of the population that the agency covers, but breaks down the reporting by county. Oklahoma City, for example, intersects with four different counties, so that the Oklahoma City Police Department reports their population separately for each.
+Some particularly important columns are `DATE.ORI.WENT.NIBRS` containing the date when the agency first reported data to NIBRS, the `AGENCY.INDICATOR` describing what type of law enforcement agency it is (e.g. city, county, state, college, tribal) or whether the agency relies on another to file its NIBRS reports (such as a transit police that reports through the municipal police). The batch header contains an estimate of the size of the population that the agency covers, but breaks down the reporting by county. Oklahoma City, for example, intersects with four different counties, so that the Oklahoma City Police Department reports their population separately for each.
 
 ```{r}
 #| cache: true
@@ -690,12 +690,21 @@ save(nibrsAdmin01, nibrsCrm02, nibrsProp03, nibrsVic04, nibrsOff05,
 # Examples using NIBRS
 
 For several of these examples we are going to need to work with dates. So, let's start by converting all the dates to proper date formats.
+We will also keep the earliest arrest per incident to reuse across the examples.
 ```{r}
 nibrsCrm02 <- nibrsCrm02 |>
    mutate(INCIDENT.DATE = ymd(INCIDENT.DATE))
 nibrsArr06 <- nibrsArr06 |>
    mutate(INCIDENT.DATE = ymd(INCIDENT.DATE),
           ARREST.DATE = ymd(ARREST.DATE))
+
+# earliest arrest date for each incident
+firstArrests <- nibrsArr06 |>
+   summarize(dateFirstArrest = {
+               non_missing <- ARREST.DATE[!is.na(ARREST.DATE)]
+               if (length(non_missing) == 0) as.Date(NA) else min(non_missing)
+            },
+            .by = c(ORI, INCIDENT.NUMBER))
 ```
 
 ## What percentage of burglaries result in an arrest? 
@@ -709,17 +718,14 @@ We will use UCR code 220 to select all the burglary offenses and check that `OFF
 ```{r examplePctBurgArrest}
 #| cache: true
 nibrsCrm02 |>
-  filter(UCR.OFFENSE.CODE=="220" &            # burglary offense code 
+  filter(UCR.OFFENSE.CODE=="220" &            # burglary offense code
          OFFENSE.ATTEMPTED.COMPLETED=="C") |> # completed
   select(ORI, INCIDENT.NUMBER) |> # incidents are only unique within ORI
   distinct() |> # remove any duplicate ORI/INCIDENT.NUMBER combos
   # compress arrest data to ORI, INCIDENT.NUMBER, and first arrest
-  left_join(nibrsArr06 |>
-               group_by(ORI, INCIDENT.NUMBER) |>
-               summarize(dataFirstArrest = min(ARREST.DATE, na.rm=TRUE),
-                         .groups="drop"),
+  left_join(firstArrests,
             by = join_by(ORI, INCIDENT.NUMBER)) |>
-  summarize(pctArrest = mean(!is.na(dataFirstArrest)))
+  summarize(pctArrest = mean(!is.na(dateFirstArrest)))
 ```
 
 ## What percentage of crimes are cleared with an arrest by month in which the offense occurred?
@@ -730,13 +736,10 @@ nibrsCrm02 |>
   mutate(INCIDENT.MONTH=month(INCIDENT.DATE, label=TRUE)) |>
   select(ORI, INCIDENT.NUMBER, INCIDENT.MONTH) |>
   distinct() |>
-  left_join(nibrsArr06 |>
-               group_by(ORI, INCIDENT.NUMBER) |>
-               summarize(dataFirstArrest = min(ARREST.DATE, na.rm=TRUE),
-                         .groups="drop"),
+  left_join(firstArrests,
             by = join_by(ORI, INCIDENT.NUMBER)) |>
   group_by(INCIDENT.MONTH) |>
-  summarize(pctArrest = mean(!is.na(dataFirstArrest)))
+  summarize(pctArrest = mean(!is.na(dateFirstArrest)))
 ```
 
 ## What is the range of times to arrest for crimes resulting in arrest?
@@ -745,15 +748,12 @@ This next example shows the issue with the March 15 cutoff for reporting to NIBR
 
 ```{r exampleTimeToArrest}
 #| cache: true
-nibrsArr06 |>
-   group_by(ORI, INCIDENT.NUMBER) |>
-   summarize(dateFirstArrest = min(ARREST.DATE, na.rm=TRUE),
-             .groups="drop") |>
-   left_join(nibrsCrm02 |> 
+firstArrests |>
+   left_join(nibrsCrm02 |>
                 select(ORI, INCIDENT.NUMBER, INCIDENT.DATE) |>
                 distinct(),
              by = join_by(ORI, INCIDENT.NUMBER)) |>
-   mutate(timeToArrest = difftime(dateFirstArrest, INCIDENT.DATE, 
+   mutate(timeToArrest = difftime(dateFirstArrest, INCIDENT.DATE,
                                   units="days") ,
           INCIDENT.MONTH = month(INCIDENT.DATE, label=TRUE)) |>
    group_by(INCIDENT.MONTH) |>
@@ -762,20 +762,17 @@ nibrsArr06 |>
    print(width=Inf)
 ```
 
-For a more fair comparison across months we can look at the percentage of crimes that result in an arrest within two months of the crime incident date. Technically, crimes on December 31st have until March 15th to have any arrests recorded (75 days), but I am going to set the threshold to within 60 days just in case it takes a few days for arrests in February for December crimes to get posted to NIBRS. Here we see that the percentage of crimes cleared with an arrest within 60 days is nearly constant across month of the year.
+For a more fair comparison across months we can look at the percentage of crimes that result in an arrest within two months of the crime incident date. Technically, crimes on December 31st have until March 15th to have any arrests recorded (75 days), but I am going to set the threshold to within 60 days just in case it takes a few days for arrests in February for December crimes to get posted to NIBRS. Here we see that the percentage of crimes cleared with an arrest within 60 days is nearly constant across the months of the year.
 ```{r exampleArrestIn2Months}
 #| cache: true
 nibrsCrm02 |>
    select(ORI, INCIDENT.NUMBER, INCIDENT.DATE) |>
    distinct() |>
-   left_join(nibrsArr06 |> 
-                group_by(ORI, INCIDENT.NUMBER, ARREST.DATE) |>
-                summarize(dateFirstArrest = min(ARREST.DATE, na.rm=TRUE),
-                          .groups = "drop"),
+   left_join(firstArrests,
              by = join_by(ORI, INCIDENT.NUMBER)) |>
-   mutate(timeToArrest = difftime(dateFirstArrest, INCIDENT.DATE, 
+   mutate(timeToArrest = difftime(dateFirstArrest, INCIDENT.DATE,
                                   units="days"),
-          arrest2Months = as.numeric(!is.na(timeToArrest) & timeToArrest <= 60),
+          arrest2Months = as.numeric(!is.na(timeToArrest) & as.numeric(timeToArrest) <= 60),
           INCIDENT.MONTH = month(INCIDENT.DATE, label=TRUE)) |>
    group_by(INCIDENT.MONTH) |>
    summarize(mean=mean(arrest2Months, na.rm=TRUE)) |>


### PR DESCRIPTION
## Summary
- polish the introductory protest notes by tightening wording, fixing slice_max usage, and correcting tag splitting
- refine the dates and times lesson to improve guidance and align the Thanksgiving exercise year with the solutions
- add a reusable first-arrest summary in the NIBRS walkthrough so arrest-rate examples handle missing arrests cleanly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d055beaa4c8328acafd9ceb85d1d52